### PR TITLE
Null check for GuiEventHandler.onItemClick

### DIFF
--- a/src/main/java/tfar/quickstack/client/GuiEventHandler.java
+++ b/src/main/java/tfar/quickstack/client/GuiEventHandler.java
@@ -64,7 +64,8 @@ public class GuiEventHandler {
 		if (!canDisplay(event.getScreen()) || !(event.getScreen() instanceof InventoryScreen) || !Screen.hasControlDown()) return;
 		InventoryScreen containerScreen = (InventoryScreen) event.getScreen();
 
-		if (containerScreen.getSlotUnderMouse().hasItem())
+		Slot slot = containerScreen.getSlotUnderMouse();
+		if (slot != null && slot.hasItem())
 		{
 			event.setCanceled(true);
 			PacketHandler.INSTANCE.sendToServer(new C2SFavoriteItemPacket(containerScreen.getSlotUnderMouse().index));


### PR DESCRIPTION
Fixes a NullPointerException when you ctrl click something that doesn't have a slot.

Like ctrl + clicking the JEI wrench icon as a shortcut for cheat mode.