### PR TITLE
Add a null check

### DIFF
--- a/src/main/java/tfar/quickstack/client/GuiEventHandler.java
+++ b/src/main/java/tfar/quickstack/client/GuiEventHandler.java
@@ -64,7 +64,7 @@ public class GuiEventHandler {
 		if (!canDisplay(event.getScreen()) || !(event.getScreen() instanceof InventoryScreen) || !Screen.hasControlDown()) return;
 		InventoryScreen containerScreen = (InventoryScreen) event.getScreen();
 
-		if (containerScreen.getSlotUnderMouse().hasItem())
+		if (containerScreen.getSlotUnderMouse() != null && containerScreen.getSlotUnderMouse().hasItem())
 		{
 			event.setCanceled(true);
 			PacketHandler.INSTANCE.sendToServer(new C2SFavoriteItemPacket(containerScreen.getSlotUnderMouse().index));


### PR DESCRIPTION
Fixes a crash when pressing the control key when inside JEI's textbox as `getSlotUnderMouse` can be null